### PR TITLE
add Go 1.22 to the build matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         go:
+          - "1.22"
           - "1.21"
           - "1.20"
           - "1.19"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated the testing environment to include Go version "1.22".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->