### PR TITLE
add Go 1.23 to the build matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,8 @@ jobs:
       fail-fast: false
       matrix:
         go:
+          - "stable"
+          - "1.23"
           - "1.22"
           - "1.21"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Expanded the CI testing matrix to include additional Go versions, enhancing compatibility and stability testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->